### PR TITLE
feat: 줌 인/아웃, 휠 이동 구현

### DIFF
--- a/src/app/(main-task)/coaching-resume/_components/FabricCanvas.tsx
+++ b/src/app/(main-task)/coaching-resume/_components/FabricCanvas.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { useEffect } from 'react';
-import * as fabric from 'fabric';
 
 // global hooks
 import { useWindowSize } from '@/hooks';
 
 // local hooks
-import { useFabricCanvas, useFabricDotGrid, useCollaborativeCanvas } from '../_hooks';
+import { useFabricCanvas, useFabricDotGrid, useCollaborativeCanvas, useZoomPan } from '../_hooks';
 
 // local stores
 import { useCanvasStore } from '../_stores';
@@ -41,6 +40,10 @@ export function FabricCanvas() {
         };
     }, [canvas, setCanvasInstance]);
 
+    // 줌 인, 아웃 / 휠 이동
+    useZoomPan(canvas);
+
+    // 화면 공유 소켓 접속
     useCollaborativeCanvas('resume-room');
 
     return <canvas ref={canvasRef} />;

--- a/src/app/(main-task)/coaching-resume/_hooks/index.ts
+++ b/src/app/(main-task)/coaching-resume/_hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useFabricCavnas';
 export * from './useFabricDotGrid';
 export * from './useCollaborativeCanvas';
+export * from './useZoomPan';

--- a/src/app/(main-task)/coaching-resume/_hooks/useZoomPan.ts
+++ b/src/app/(main-task)/coaching-resume/_hooks/useZoomPan.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as fabric from 'fabric';
+
+export function useZoomPan(canvas: fabric.Canvas | null) {
+    useEffect(() => {
+        if (!canvas) return;
+
+        const handleWheel = (opt: fabric.TEvent<WheelEvent>) => {
+            const e = opt.e;
+            const vpt = canvas.viewportTransform!;
+
+            if (e.altKey || e.metaKey) {
+                let zoom = canvas.getZoom();
+                zoom *= 0.999 ** e.deltaY;
+                if (zoom > 3) zoom = 3;
+                if (zoom < 0.5) zoom = 0.5;
+
+                const point = new fabric.Point(e.offsetX, e.offsetY);
+                canvas.zoomToPoint(point, zoom);
+            } else {
+                vpt[4] -= e.deltaX;
+                vpt[5] -= e.deltaY;
+                canvas.requestRenderAll();
+            }
+
+            e.preventDefault();
+            e.stopPropagation();
+        };
+
+        canvas.on('mouse:wheel', handleWheel);
+
+        return () => {
+            canvas.off('mouse:wheel', handleWheel);
+        };
+    }, [canvas]);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 코칭 이력서 캔버스에 확대/축소 및 이동(패닝) 제스처를 추가했습니다.
  - Alt/Option 또는 ⌘/Meta 키를 누른 채 스크롤하면 커서 기준으로 확대/축소됩니다(50%~300% 범위).
  - 키 없이 스크롤하면 캔버스가 부드럽게 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->