### PR TITLE
[ feat ] 음성분석/영상분석 서버 연동 및 결과페이지 출력 구현

### DIFF
--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api';
+export const API_BASE_URL =
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api` || 'http://localhost:4000/api';
 
 export const apiConfig = {
     baseURL: API_BASE_URL,

--- a/src/apis/interview-api.ts
+++ b/src/apis/interview-api.ts
@@ -34,7 +34,7 @@ export const analyzeInterview = async (
     request: InterviewAnalysisRequest,
 ): Promise<InterviewAnalysisResponse> => {
     // 백엔드 서버 주소로 API 호출
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/interview/analyze`, {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/interview/analyze`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',

--- a/src/app/(main-task)/ai-interview/result/page.tsx
+++ b/src/app/(main-task)/ai-interview/result/page.tsx
@@ -26,6 +26,10 @@ import {
     BulbOutlined,
     RiseOutlined,
     WarningOutlined,
+    SoundOutlined,
+    AudioOutlined,
+    SmileOutlined,
+    ThunderboltOutlined,
 } from '@ant-design/icons';
 import Link from 'next/link';
 
@@ -63,6 +67,57 @@ interface QAPair {
     answer: string;
 }
 
+// ▼ ADDED: 음성 분석 타입들
+interface AudioFeatures {
+    f0_mean: number;
+    f0_std: number;
+    f0_cv?: number;
+    f0_std_semitone?: number;
+    rms_std: number;
+    rms_cv: number;
+    jitter_like: number;
+    shimmer_like: number;
+    silence_ratio: number;
+    sr: number;
+}
+interface AudioPerQuestion {
+    questionNumber: number;
+    question: string;
+    audioFeatures?: AudioFeatures;
+    audioUrl?: string;
+}
+
+// === ▼ ADDED: 영상(시각) 집계 타입들 (백엔드 응답 구조에 맞춤) ===
+type PresenceKey = 'good' | 'average' | 'needs_improvement';
+type LevelKey = 'ok' | 'info' | 'warning' | 'critical';
+interface VisualQuestionAgg {
+    count: number;
+    confidence_mean: number | null;
+    confidence_max: number | null;
+    smile_mean: number | null;
+    smile_max: number | null;
+    presence_dist: Record<PresenceKey, number>;
+    level_dist: Record<LevelKey, number>;
+    landmarks_mean?: {
+        leftEye?: { x: number; y: number };
+        rightEye?: { x: number; y: number };
+        nose?: { x: number; y: number };
+    };
+    startedAt?: number;
+    endedAt?: number;
+}
+interface VisualSessionAggOverall {
+    count: number;
+    confidence_mean: number | null;
+    confidence_max: number | null;
+    smile_mean: number | null;
+    smile_max: number | null;
+    presence_dist: Record<PresenceKey, number>;
+    level_dist: Record<LevelKey, number>;
+    startedAt?: number;
+    endedAt?: number;
+}
+
 export default function AiInterviewResultPage() {
     const [analysisResult, setAnalysisResult] = useState<InterviewAnalysisResult | null>(null);
     const [analysisError, setAnalysisError] = useState<InterviewAnalysisError | null>(null);
@@ -70,24 +125,65 @@ export default function AiInterviewResultPage() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
+    // ▼ ADDED: 음성 분석 상태
+    const [audioPerQuestion, setAudioPerQuestion] = useState<AudioPerQuestion[] | null>(null);
+    const [audioOverall, setAudioOverall] = useState<Partial<AudioFeatures> | null>(null);
+
+    // === ▼ ADDED: 영상(시각) 집계 상태 ===
+    const [visualPerQuestion, setVisualPerQuestion] = useState<Record<
+        string,
+        VisualQuestionAgg
+    > | null>(null);
+    const [visualOverall, setVisualOverall] = useState<VisualSessionAggOverall | null>(null);
+
     useEffect(() => {
         // localStorage에서 데이터 가져오기
         try {
             const storedAnalysis = localStorage.getItem('interviewAnalysis');
             const storedQA = localStorage.getItem('interviewQA');
 
+            // ▼ ADDED: 음성 분석 저장본 가져오기
+            const storedAudioPerQ = localStorage.getItem('interviewAudioPerQuestion');
+            const storedAudioOverall = localStorage.getItem('interviewAudioOverall');
+
+            // ▼ ADDED: 영상 분석
+            const storedVisualPerQ = localStorage.getItem('interviewVisualPerQuestion');
+            const storedVisualOverall = localStorage.getItem('interviewVisualOverall');
+
             if (storedAnalysis && storedQA) {
                 const analysis = JSON.parse(storedAnalysis);
                 const qa = JSON.parse(storedQA);
 
                 // API 실패 여부 확인
-                if (analysis.error) {
-                    setAnalysisError(analysis);
-                } else {
-                    setAnalysisResult(analysis);
-                }
+                if (analysis.error) setAnalysisError(analysis);
+                else setAnalysisResult(analysis);
 
                 setQaList(qa);
+
+                // ▼ ADDED: 음성 분석 상태 주입(없으면 null 유지)
+                if (storedAudioPerQ) {
+                    try {
+                        setAudioPerQuestion(JSON.parse(storedAudioPerQ));
+                    } catch {}
+                }
+                if (storedAudioOverall) {
+                    try {
+                        setAudioOverall(JSON.parse(storedAudioOverall));
+                    } catch {}
+                }
+
+                // ▼ ADDED: 영상
+                if (storedVisualPerQ) {
+                    try {
+                        setVisualPerQuestion(JSON.parse(storedVisualPerQ));
+                    } catch {}
+                }
+                if (storedVisualOverall) {
+                    try {
+                        setVisualOverall(JSON.parse(storedVisualOverall));
+                    } catch {}
+                }
+
                 setLoading(false);
             } else {
                 setError('면접 결과 데이터를 찾을 수 없습니다.');
@@ -105,19 +201,65 @@ export default function AiInterviewResultPage() {
         if (score >= 70) return '#faad14';
         return '#ff4d4f';
     };
-
     const getScoreLevel = (score: number) => {
         if (score >= 90) return '우수';
         if (score >= 80) return '양호';
         if (score >= 70) return '보통';
         return '개선 필요';
     };
-
     const getScoreIcon = (score: number) => {
         if (score >= 90) return <TrophyOutlined className='text-yellow-500' />;
         if (score >= 80) return <StarOutlined className='text-blue-500' />;
         if (score >= 70) return <CheckCircleOutlined className='text-orange-500' />;
         return <WarningOutlined className='text-red-500' />;
+    };
+
+    // ▼ ADDED: 간단 점수화(프론트 계산) — 서버에서 준 원시지표를 보기 좋게
+    const clamp01 = (x: number) => Math.max(0, Math.min(1, x));
+    const toneScore = (f: AudioFeatures | undefined) => {
+        if (!f) return undefined;
+        if (Number.isFinite(f.f0_std_semitone) && (f.f0_std_semitone as number) > 0) {
+            const st = f.f0_std_semitone as number; // 세미톤 표준편차(강건)
+            const lo = 0.15,
+                hi = 0.9; // 0.15→100점, 0.90→0점
+            const t = Math.min(1, Math.max(0, (st - lo) / (hi - lo)));
+            return Math.round((1 - t) * 100);
+        }
+        if (Number.isFinite(f.f0_cv) && (f.f0_cv as number) > 0) {
+            const cv = f.f0_cv as number; // CV 0.05→100, 0.30→0
+            const lo = 0.05,
+                hi = 0.3;
+            const t = Math.min(1, Math.max(0, (cv - lo) / (hi - lo)));
+            return Math.round((1 - t) * 100);
+        }
+        const std = f.f0_std; // 폴백: 절대 표준편차
+        const t = Math.min(1, std / 120);
+        return Math.round((1 - t) * 100);
+    };
+    const vibratoScore = (f: AudioFeatures | undefined) => {
+        if (!f) return undefined;
+        const nj = Math.min(1, (f.jitter_like ?? 0) / 1.0);
+        const ns = Math.min(1, (f.shimmer_like ?? 0) / 1.0);
+        const nr = Math.min(1, (f.rms_cv ?? 0) / 2.0);
+        const bad = nj * 0.4 + ns * 0.4 + nr * 0.2;
+        return Math.round((1 - bad) * 100);
+    };
+    const paceScore = (f: AudioFeatures | undefined) => {
+        if (!f) return undefined;
+        const talk = 1 - (f.silence_ratio ?? 0);
+        const target = 0.6;
+        const err = Math.abs(talk - target) / target;
+        return Math.round((1 - clamp01(err)) * 100);
+    };
+
+    const audioScoreColor = (v?: number) => (typeof v === 'number' ? getScoreColor(v) : '#d9d9d9');
+
+    // === ▼ ADDED: 영상 지표 간단 스코어링 (프론트 보기 좋게)
+    const visualScoreColor = (v?: number | null) =>
+        typeof v === 'number' ? getScoreColor(Math.round(v * 100)) : '#d9d9d9';
+    const pct = (n?: number | null, total?: number | null) => {
+        if (!n || !total || total <= 0) return '0%';
+        return `${((n / total) * 100).toFixed(0)}%`;
     };
 
     if (loading) {
@@ -200,6 +342,420 @@ export default function AiInterviewResultPage() {
                             )}
                         />
                     </Card>
+
+                    {/* ▼ ADDED: 질문별 음성 분석 결과 (요약) */}
+                    {audioPerQuestion && audioPerQuestion.length > 0 && (
+                        <Card title='질문별 음성 분석 요약' className='!border-0 !shadow-lg mb-8'>
+                            <List
+                                dataSource={audioPerQuestion}
+                                renderItem={(item) => {
+                                    const tone = toneScore(item.audioFeatures);
+                                    const vib = vibratoScore(item.audioFeatures);
+                                    const pace = paceScore(item.audioFeatures);
+                                    return (
+                                        <List.Item>
+                                            <div className='w-full'>
+                                                <div className='flex justify-between items-start mb-3'>
+                                                    <Text strong className='text-lg'>
+                                                        Q{item.questionNumber}. {item.question}
+                                                    </Text>
+                                                    <Space>
+                                                        {typeof tone === 'number' && (
+                                                            <Tag color={audioScoreColor(tone)}>
+                                                                <SoundOutlined /> 톤 {tone}
+                                                            </Tag>
+                                                        )}
+                                                        {typeof vib === 'number' && (
+                                                            <Tag color={audioScoreColor(vib)}>
+                                                                <AudioOutlined /> 떨림 {vib}
+                                                            </Tag>
+                                                        )}
+                                                        {typeof pace === 'number' && (
+                                                            <Tag color={audioScoreColor(pace)}>
+                                                                <ClockCircleOutlined /> 말빠르기{' '}
+                                                                {pace}
+                                                            </Tag>
+                                                        )}
+                                                    </Space>
+                                                </div>
+
+                                                {item.audioUrl && (
+                                                    <audio
+                                                        controls
+                                                        src={item.audioUrl}
+                                                        className='w-full mb-3'
+                                                    />
+                                                )}
+
+                                                {item.audioFeatures && (
+                                                    <Row gutter={[16, 16]}>
+                                                        <Col xs={24} sm={12} md={6}>
+                                                            <Card size='small'>
+                                                                <Statistic
+                                                                    title='f0_mean (Hz)'
+                                                                    value={item.audioFeatures.f0_mean?.toFixed(
+                                                                        1,
+                                                                    )}
+                                                                />
+                                                            </Card>
+                                                        </Col>
+                                                        <Col xs={24} sm={12} md={6}>
+                                                            <Card size='small'>
+                                                                <Statistic
+                                                                    title='f0_std (Hz)'
+                                                                    value={item.audioFeatures.f0_std?.toFixed(
+                                                                        2,
+                                                                    )}
+                                                                />
+                                                            </Card>
+                                                        </Col>
+                                                        <Col xs={24} sm={12} md={6}>
+                                                            <Card size='small'>
+                                                                <Statistic
+                                                                    title='rms_cv'
+                                                                    value={item.audioFeatures.rms_cv?.toFixed(
+                                                                        3,
+                                                                    )}
+                                                                />
+                                                            </Card>
+                                                        </Col>
+                                                        <Col xs={24} sm={12} md={6}>
+                                                            <Card size='small'>
+                                                                <Statistic
+                                                                    title='침묵 비율'
+                                                                    value={`${((item.audioFeatures.silence_ratio ?? 0) * 100).toFixed(1)}%`}
+                                                                />
+                                                            </Card>
+                                                        </Col>
+                                                    </Row>
+                                                )}
+                                            </div>
+                                        </List.Item>
+                                    );
+                                }}
+                            />
+                        </Card>
+                    )}
+
+                    {/* ▼ ADDED: 음성 분석 - 전체 요약 */}
+                    {audioOverall && (
+                        <Card title='종합 음성 분석' className='!border-0 !shadow-lg mb-8'>
+                            <Row gutter={[16, 16]}>
+                                {/* 간단 가시화: 톤/떨림/말빠르기 점수 (평균 원시치 기반) */}
+                                <Col xs={24} md={8}>
+                                    <Card size='small'>
+                                        <div className='text-center mb-8'>
+                                            <div className='text-base text-gray-600 mb-2'>
+                                                톤 안정성
+                                            </div>
+                                            <div
+                                                className='text-4xl font-bold'
+                                                style={{
+                                                    color: audioScoreColor(
+                                                        toneScore(audioOverall as AudioFeatures),
+                                                    ),
+                                                }}
+                                            >
+                                                {toneScore(audioOverall as AudioFeatures) ?? '-'}
+                                            </div>
+                                        </div>
+                                        <Statistic
+                                            title='평균 f0_mean (Hz)'
+                                            value={(audioOverall.f0_mean ?? 0).toFixed(1)}
+                                        />
+                                        <Statistic
+                                            title='평균 f0_std (Hz)'
+                                            value={(audioOverall.f0_std ?? 0).toFixed(2)}
+                                        />
+                                    </Card>
+                                </Col>
+                                <Col xs={24} md={8}>
+                                    <Card size='small'>
+                                        <div className='text-center mb-8'>
+                                            <div className='text-base text-gray-600 mb-2'>
+                                                목소리 떨림
+                                            </div>
+                                            <div
+                                                className='text-4xl font-bold'
+                                                style={{
+                                                    color: audioScoreColor(
+                                                        vibratoScore(audioOverall as AudioFeatures),
+                                                    ),
+                                                }}
+                                            >
+                                                {vibratoScore(audioOverall as AudioFeatures) ?? '-'}
+                                            </div>
+                                        </div>
+                                        <Statistic
+                                            title='평균 jitter_like'
+                                            value={(audioOverall.jitter_like ?? 0).toFixed(3)}
+                                        />
+                                        <Statistic
+                                            title='평균 shimmer_like'
+                                            value={(audioOverall.shimmer_like ?? 0).toFixed(3)}
+                                        />
+                                    </Card>
+                                </Col>
+                                <Col xs={24} md={8}>
+                                    <Card size='small'>
+                                        <div className='text-center mb-8'>
+                                            <div className='text-base text-gray-600 mb-2'>
+                                                말 빠르기(프록시)
+                                            </div>
+                                            <div
+                                                className='text-4xl font-bold'
+                                                style={{
+                                                    color: audioScoreColor(
+                                                        paceScore(audioOverall as AudioFeatures),
+                                                    ),
+                                                }}
+                                            >
+                                                {paceScore(audioOverall as AudioFeatures) ?? '-'}
+                                            </div>
+                                        </div>
+                                        <Statistic
+                                            title='평균 침묵 비율'
+                                            value={`${((audioOverall.silence_ratio ?? 0) * 100).toFixed(1)}%`}
+                                        />
+                                        <Statistic
+                                            title='평균 rms_cv'
+                                            value={(audioOverall.rms_cv ?? 0).toFixed(3)}
+                                        />
+                                    </Card>
+                                </Col>
+                            </Row>
+                        </Card>
+                    )}
+
+                    {/* ▼ ADDED: 질문별 영상 요약 */}
+                    {visualPerQuestion && (
+                        <Card title='질문별 영상 분석 요약' className='!border-0 !shadow-lg mb-8'>
+                            <List
+                                dataSource={qaList}
+                                renderItem={(qa, index) => {
+                                    const qid = `q${index + 1}`;
+                                    const v = visualPerQuestion[qid] as
+                                        | VisualQuestionAgg
+                                        | undefined;
+                                    return (
+                                        <List.Item>
+                                            <div className='w-full'>
+                                                <div className='flex justify-between items-start mb-3'>
+                                                    <Text strong className='text-lg'>
+                                                        Q{index + 1}. {qa.question}
+                                                    </Text>
+                                                    {v && (
+                                                        <Space>
+                                                            {/* 간단 표시: 자신감/미소 평균 */}
+                                                            {typeof v.confidence_mean ===
+                                                                'number' && (
+                                                                <Tag
+                                                                    color={visualScoreColor(
+                                                                        v.confidence_mean,
+                                                                    )}
+                                                                >
+                                                                    <ThunderboltOutlined /> 자신감{' '}
+                                                                    {(
+                                                                        v.confidence_mean * 100
+                                                                    ).toFixed(0)}
+                                                                </Tag>
+                                                            )}
+                                                            {typeof v.smile_mean === 'number' && (
+                                                                <Tag
+                                                                    color={visualScoreColor(
+                                                                        v.smile_mean,
+                                                                    )}
+                                                                >
+                                                                    <SmileOutlined /> 미소{' '}
+                                                                    {(v.smile_mean * 100).toFixed(
+                                                                        0,
+                                                                    )}
+                                                                </Tag>
+                                                            )}
+                                                        </Space>
+                                                    )}
+                                                </div>
+                                                {v && (
+                                                    <Row gutter={[16, 16]}>
+                                                        <Col xs={24} sm={12} md={6}>
+                                                            <Card size='small'>
+                                                                <Statistic
+                                                                    title='샘플 수'
+                                                                    value={v.count}
+                                                                />
+                                                            </Card>
+                                                        </Col>
+                                                        <Col xs={24} sm={12} md={6}>
+                                                            <Card size='small'>
+                                                                <Statistic
+                                                                    title='presence: good'
+                                                                    value={pct(
+                                                                        v.presence_dist.good,
+                                                                        v.count,
+                                                                    )}
+                                                                />
+                                                                <Statistic
+                                                                    title='presence: avg'
+                                                                    value={pct(
+                                                                        v.presence_dist.average,
+                                                                        v.count,
+                                                                    )}
+                                                                />
+                                                                <Statistic
+                                                                    title='presence: needs'
+                                                                    value={pct(
+                                                                        v.presence_dist
+                                                                            .needs_improvement,
+                                                                        v.count,
+                                                                    )}
+                                                                />
+                                                            </Card>
+                                                        </Col>
+                                                        <Col xs={24} sm={12} md={6}>
+                                                            <Card size='small'>
+                                                                <Statistic
+                                                                    title='level: ok'
+                                                                    value={pct(
+                                                                        v.level_dist.ok,
+                                                                        v.count,
+                                                                    )}
+                                                                />
+                                                                <Statistic
+                                                                    title='level: warn'
+                                                                    value={pct(
+                                                                        v.level_dist.warning,
+                                                                        v.count,
+                                                                    )}
+                                                                />
+                                                            </Card>
+                                                        </Col>
+                                                        <Col xs={24} sm={12} md={6}>
+                                                            <Card size='small'>
+                                                                <Statistic
+                                                                    title='conf_mean'
+                                                                    value={
+                                                                        typeof v.confidence_mean ===
+                                                                        'number'
+                                                                            ? (
+                                                                                  v.confidence_mean *
+                                                                                  100
+                                                                              ).toFixed(0)
+                                                                            : '-'
+                                                                    }
+                                                                />
+                                                                <Statistic
+                                                                    title='smile_mean'
+                                                                    value={
+                                                                        typeof v.smile_mean ===
+                                                                        'number'
+                                                                            ? (
+                                                                                  v.smile_mean * 100
+                                                                              ).toFixed(0)
+                                                                            : '-'
+                                                                    }
+                                                                />
+                                                            </Card>
+                                                        </Col>
+                                                    </Row>
+                                                )}
+                                            </div>
+                                        </List.Item>
+                                    );
+                                }}
+                            />
+                        </Card>
+                    )}
+
+                    {/* ▼ ADDED: 종합 영상 분석 */}
+                    {visualOverall && (
+                        <Card title='종합 영상 분석' className='!border-0 !shadow-lg mb-8'>
+                            <Row gutter={[16, 16]}>
+                                <Col xs={24} md={8}>
+                                    <Card size='small'>
+                                        <div className='text-center mb-8'>
+                                            <div className='text-base text-gray-600 mb-2'>
+                                                전체 자신감(평균)
+                                            </div>
+                                            <div
+                                                className='text-4xl font-bold'
+                                                style={{
+                                                    color: visualScoreColor(
+                                                        visualOverall.confidence_mean,
+                                                    ),
+                                                }}
+                                            >
+                                                {typeof visualOverall.confidence_mean === 'number'
+                                                    ? (visualOverall.confidence_mean * 100).toFixed(
+                                                          0,
+                                                      )
+                                                    : '-'}
+                                            </div>
+                                        </div>
+                                        <Statistic title='샘플 수' value={visualOverall.count} />
+                                    </Card>
+                                </Col>
+                                <Col xs={24} md={8}>
+                                    <Card size='small'>
+                                        <div className='text-center mb-8'>
+                                            <div className='text-base text-gray-600 mb-2'>
+                                                전체 미소(평균)
+                                            </div>
+                                            <div
+                                                className='text-4xl font-bold'
+                                                style={{
+                                                    color: visualScoreColor(
+                                                        visualOverall.smile_mean,
+                                                    ),
+                                                }}
+                                            >
+                                                {typeof visualOverall.smile_mean === 'number'
+                                                    ? (visualOverall.smile_mean * 100).toFixed(0)
+                                                    : '-'}
+                                            </div>
+                                        </div>
+                                        <Statistic
+                                            title='presence good'
+                                            value={pct(
+                                                visualOverall.presence_dist.good,
+                                                visualOverall.count,
+                                            )}
+                                        />
+                                        <Statistic
+                                            title='level ok'
+                                            value={pct(
+                                                visualOverall.level_dist.ok,
+                                                visualOverall.count,
+                                            )}
+                                        />
+                                    </Card>
+                                </Col>
+                                <Col xs={24} md={8}>
+                                    <Card size='small'>
+                                        <div className='text-center mb-8'>
+                                            <div className='text-base text-gray-600 mb-2'>
+                                                주의/경고 비중
+                                            </div>
+                                            <div className='text-4xl font-bold'>
+                                                {pct(
+                                                    visualOverall.level_dist.warning +
+                                                        visualOverall.level_dist.critical,
+                                                    visualOverall.count,
+                                                )}
+                                            </div>
+                                        </div>
+                                        <Statistic
+                                            title='경고(warn)'
+                                            value={visualOverall.level_dist.warning}
+                                        />
+                                        <Statistic
+                                            title='치명(critical)'
+                                            value={visualOverall.level_dist.critical}
+                                        />
+                                    </Card>
+                                </Col>
+                            </Row>
+                        </Card>
+                    )}
 
                     {/* 액션 버튼 */}
                     <div className='text-center'>
@@ -375,7 +931,6 @@ export default function AiInterviewResultPage() {
                         renderItem={(qa, index) => {
                             const questionKey = `question_${index + 1}`;
                             const feedback = analysisResult.detailed_feedback[questionKey];
-
                             return (
                                 <List.Item>
                                     <div className='w-full'>
@@ -392,13 +947,11 @@ export default function AiInterviewResultPage() {
                                                 </Tag>
                                             )}
                                         </div>
-
                                         <div className='bg-gray-50 p-4 rounded-lg mb-3'>
                                             <Text type='secondary' className='text-sm'>
                                                 <strong>답변:</strong> {qa.answer}
                                             </Text>
                                         </div>
-
                                         {feedback && (
                                             <div className='bg-blue-50 p-4 rounded-lg'>
                                                 <Text className='text-sm'>
@@ -412,6 +965,276 @@ export default function AiInterviewResultPage() {
                         }}
                     />
                 </Card>
+
+                {/* ▼ ADDED: 종합 영상 분석 */}
+                {visualOverall && (
+                    <Card title='종합 영상 분석' className='!border-0 !shadow-lg mb-8'>
+                        <Row gutter={[16, 16]}>
+                            <Col xs={24} md={8}>
+                                <Card size='small'>
+                                    <div className='text-center mb-8'>
+                                        <div className='text-base text-gray-600 mb-2'>
+                                            전체 자신감(평균)
+                                        </div>
+                                        <div
+                                            className='text-4xl font-bold'
+                                            style={{
+                                                color: visualScoreColor(
+                                                    visualOverall.confidence_mean,
+                                                ),
+                                            }}
+                                        >
+                                            {typeof visualOverall.confidence_mean === 'number'
+                                                ? (visualOverall.confidence_mean * 100).toFixed(0)
+                                                : '-'}
+                                        </div>
+                                    </div>
+                                    <Statistic title='샘플 수' value={visualOverall.count} />
+                                </Card>
+                            </Col>
+                            <Col xs={24} md={8}>
+                                <Card size='small'>
+                                    <div className='text-center mb-8'>
+                                        <div className='text-base text-gray-600 mb-2'>
+                                            전체 미소(평균)
+                                        </div>
+                                        <div
+                                            className='text-4xl font-bold'
+                                            style={{
+                                                color: visualScoreColor(visualOverall.smile_mean),
+                                            }}
+                                        >
+                                            {typeof visualOverall.smile_mean === 'number'
+                                                ? (visualOverall.smile_mean * 100).toFixed(0)
+                                                : '-'}
+                                        </div>
+                                    </div>
+                                    <Statistic
+                                        title='presence good'
+                                        value={pct(
+                                            visualOverall.presence_dist.good,
+                                            visualOverall.count,
+                                        )}
+                                    />
+                                    <Statistic
+                                        title='level ok'
+                                        value={pct(
+                                            visualOverall.level_dist.ok,
+                                            visualOverall.count,
+                                        )}
+                                    />
+                                </Card>
+                            </Col>
+                            <Col xs={24} md={8}>
+                                <Card size='small'>
+                                    <div className='text-center mb-8'>
+                                        <div className='text-base text-gray-600 mb-2'>
+                                            주의/경고 비중
+                                        </div>
+                                        <div className='text-4xl font-bold'>
+                                            {pct(
+                                                visualOverall.level_dist.warning +
+                                                    visualOverall.level_dist.critical,
+                                                visualOverall.count,
+                                            )}
+                                        </div>
+                                    </div>
+                                    <Statistic
+                                        title='경고(warn)'
+                                        value={visualOverall.level_dist.warning}
+                                    />
+                                    <Statistic
+                                        title='치명(critical)'
+                                        value={visualOverall.level_dist.critical}
+                                    />
+                                </Card>
+                            </Col>
+                        </Row>
+                    </Card>
+                )}
+
+                {/* ▼ ADDED: 음성 분석 - 전체 요약 */}
+                {audioOverall && (
+                    <Card title='종합 음성 분석' className='!border-0 !shadow-lg mb-8'>
+                        <Row gutter={[16, 16]}>
+                            {/* 간단 가시화: 톤/떨림/말빠르기 점수 (평균 원시치 기반) */}
+                            <Col xs={24} md={8}>
+                                <Card size='small'>
+                                    <div className='text-center mb-8'>
+                                        <div className='text-base text-gray-600 mb-2'>
+                                            톤 안정성
+                                        </div>
+                                        <div
+                                            className='text-4xl font-bold'
+                                            style={{
+                                                color: audioScoreColor(
+                                                    toneScore(audioOverall as AudioFeatures),
+                                                ),
+                                            }}
+                                        >
+                                            {toneScore(audioOverall as AudioFeatures) ?? '-'}
+                                        </div>
+                                    </div>
+                                    <Statistic
+                                        title='평균 f0_mean (Hz)'
+                                        value={(audioOverall.f0_mean ?? 0).toFixed(1)}
+                                    />
+                                    <Statistic
+                                        title='평균 f0_std (Hz)'
+                                        value={(audioOverall.f0_std ?? 0).toFixed(2)}
+                                    />
+                                </Card>
+                            </Col>
+                            <Col xs={24} md={8}>
+                                <Card size='small'>
+                                    <div className='text-center mb-8'>
+                                        <div className='text-base text-gray-600 mb-2'>
+                                            목소리 떨림
+                                        </div>
+                                        <div
+                                            className='text-4xl font-bold'
+                                            style={{
+                                                color: audioScoreColor(
+                                                    vibratoScore(audioOverall as AudioFeatures),
+                                                ),
+                                            }}
+                                        >
+                                            {vibratoScore(audioOverall as AudioFeatures) ?? '-'}
+                                        </div>
+                                    </div>
+                                    <Statistic
+                                        title='평균 jitter_like'
+                                        value={(audioOverall.jitter_like ?? 0).toFixed(3)}
+                                    />
+                                    <Statistic
+                                        title='평균 shimmer_like'
+                                        value={(audioOverall.shimmer_like ?? 0).toFixed(3)}
+                                    />
+                                </Card>
+                            </Col>
+                            <Col xs={24} md={8}>
+                                <Card size='small'>
+                                    <div className='text-center mb-8'>
+                                        <div className='text-base text-gray-600 mb-2'>
+                                            말 빠르기(프록시)
+                                        </div>
+                                        <div
+                                            className='text-4xl font-bold'
+                                            style={{
+                                                color: audioScoreColor(
+                                                    paceScore(audioOverall as AudioFeatures),
+                                                ),
+                                            }}
+                                        >
+                                            {paceScore(audioOverall as AudioFeatures) ?? '-'}
+                                        </div>
+                                    </div>
+                                    <Statistic
+                                        title='평균 침묵 비율'
+                                        value={`${((audioOverall.silence_ratio ?? 0) * 100).toFixed(1)}%`}
+                                    />
+                                    <Statistic
+                                        title='평균 rms_cv'
+                                        value={(audioOverall.rms_cv ?? 0).toFixed(3)}
+                                    />
+                                </Card>
+                            </Col>
+                        </Row>
+                    </Card>
+                )}
+
+                {/* ▼ ADDED: 음성 분석 - 질문별 상세 */}
+                {audioPerQuestion && audioPerQuestion.length > 0 && (
+                    <Card title='질문별 음성 분석 상세' className='!border-0 !shadow-lg mb-8'>
+                        <List
+                            dataSource={audioPerQuestion}
+                            renderItem={(item) => {
+                                const tone = toneScore(item.audioFeatures as AudioFeatures);
+                                const vib = vibratoScore(item.audioFeatures as AudioFeatures);
+                                const pace = paceScore(item.audioFeatures as AudioFeatures);
+                                return (
+                                    <List.Item>
+                                        <div className='w-full'>
+                                            <div className='flex justify-between items-start mb-3'>
+                                                <Text strong className='text-lg'>
+                                                    Q{item.questionNumber}. {item.question}
+                                                </Text>
+                                                <Space>
+                                                    {typeof tone === 'number' && (
+                                                        <Tag color={audioScoreColor(tone)}>
+                                                            <SoundOutlined /> 톤 {tone}
+                                                        </Tag>
+                                                    )}
+                                                    {typeof vib === 'number' && (
+                                                        <Tag color={audioScoreColor(vib)}>
+                                                            <AudioOutlined /> 떨림 {vib}
+                                                        </Tag>
+                                                    )}
+                                                    {typeof pace === 'number' && (
+                                                        <Tag color={audioScoreColor(pace)}>
+                                                            <ClockCircleOutlined /> 말빠르기 {pace}
+                                                        </Tag>
+                                                    )}
+                                                </Space>
+                                            </div>
+
+                                            {item.audioUrl && (
+                                                <audio
+                                                    controls
+                                                    src={item.audioUrl}
+                                                    className='w-full mb-3'
+                                                />
+                                            )}
+
+                                            {item.audioFeatures && (
+                                                <Row gutter={[16, 16]}>
+                                                    <Col xs={24} sm={12} md={6}>
+                                                        <Card size='small'>
+                                                            <Statistic
+                                                                title='f0_mean (Hz)'
+                                                                value={item.audioFeatures.f0_mean.toFixed(
+                                                                    1,
+                                                                )}
+                                                            />
+                                                        </Card>
+                                                    </Col>
+                                                    <Col xs={24} sm={12} md={6}>
+                                                        <Card size='small'>
+                                                            <Statistic
+                                                                title='f0_std (Hz)'
+                                                                value={item.audioFeatures.f0_std.toFixed(
+                                                                    2,
+                                                                )}
+                                                            />
+                                                        </Card>
+                                                    </Col>
+                                                    <Col xs={24} sm={12} md={6}>
+                                                        <Card size='small'>
+                                                            <Statistic
+                                                                title='rms_cv'
+                                                                value={item.audioFeatures.rms_cv.toFixed(
+                                                                    3,
+                                                                )}
+                                                            />
+                                                        </Card>
+                                                    </Col>
+                                                    <Col xs={24} sm={12} md={6}>
+                                                        <Card size='small'>
+                                                            <Statistic
+                                                                title='침묵 비율'
+                                                                value={`${(item.audioFeatures.silence_ratio * 100).toFixed(1)}%`}
+                                                            />
+                                                        </Card>
+                                                    </Col>
+                                                </Row>
+                                            )}
+                                        </div>
+                                    </List.Item>
+                                );
+                            }}
+                        />
+                    </Card>
+                )}
 
                 {/* 추천사항 */}
                 <Card title='추천사항' className='!border-0 !shadow-lg mb-8'>


### PR DESCRIPTION
- 음성 분석 결과는 ai 서버와 연결하여 구현했습니다.
- 영상 분석 데이터는 각 문항별로 브라우저에 저장해 놓았다가, 답변 종료 시 평균값 등을 계산하여 서버로 전송합니다.
- 면접이 종료되면 각 문항별 음성/영상 분석 결과 및 면접 전체 분석 결과를 리포트로 출력합니다.
- 결과 리포트는 아직 STT/LLM이 구현되지 않아 API 실패 시 화면을 띄우고 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 면접 결과 페이지에 음성·영상 분석 패널 추가: 질문별/종합 지표(자신감, 미소, 톤, 떨림, 말 빠르기 등)와 색상 기반 인디케이터 제공
  - 면접 진행 중 음성 녹음 및 자동 분석 지원, 질문 단위로 시각 신호를 집계하여 결과에 반영
- 리팩터링
  - 웹캠 초기화 및 종료 흐름 안정화, 참조 기반 제어로 질문 시작/종료 연동
  - 분석 로그 간소화 및 오버레이 업데이트 지연 개선으로 사용 경험 향상
- 기타
  - API 기본 URL 및 엔드포인트 환경설정 정비로 서비스 연결성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->