### PR TITLE
webRTC 연동 후 영상통화 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "preinstall": "npx only-allow pnpm",
-        "dev": "next dev",
+        "dev": "next dev -H 0.0.0.0",
         "build": "next build",
         "build:local": "next build",
         "build:prod": "next build",

--- a/src/app/(main-task)/coaching-resume/_components/CameraBox.tsx
+++ b/src/app/(main-task)/coaching-resume/_components/CameraBox.tsx
@@ -61,6 +61,7 @@ export function CameraBox({
                     playsInline
                     muted={isLocal}
                     className='w-full h-full object-cover'
+                    style={{ transform: 'scaleX(-1)' }}
                 />
             )}
 

--- a/src/app/(main-task)/coaching-resume/_components/CameraBox.tsx
+++ b/src/app/(main-task)/coaching-resume/_components/CameraBox.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useMemo } from 'react';
+import { useMemo, useRef, useEffect } from 'react';
 import { useCanvasStore } from '../_stores';
 
 interface ICameraBox {
@@ -9,26 +9,52 @@ interface ICameraBox {
     isLocal: boolean;
     isSpeaking: boolean;
     profileImg?: string;
+    stream?: MediaStream | null; // ✅ 추가
 }
 
-export function CameraBox({ name = '이름없음', isLocal, isSpeaking, profileImg }: ICameraBox) {
+export function CameraBox({
+    name = '이름없음',
+    isLocal,
+    isSpeaking,
+    profileImg,
+    stream,
+}: ICameraBox) {
     const isCamEnabled = useCanvasStore((s) => s.isCamEnabled);
     const isMicEnabled = useCanvasStore((s) => s.isMicEnabled);
+    const videoRef = useRef<HTMLVideoElement>(null);
+
     const speakingStyle = isSpeaking ? 'ring-2 ring-blue-500' : '';
-    const bgClass = 'bg-[#0b1b2b]'; // 어두운 파란색 배경
+    const bgClass = 'bg-[#0b1b2b]';
 
     const initial = useMemo(() => {
         const base = isLocal ? 'You' : name || '';
         return base.trim().charAt(0).toUpperCase() || 'U';
     }, [isLocal, name]);
 
-    const showProfileFallback = isLocal && !isCamEnabled;
+    const showProfileFallback = !stream || (isLocal && !isCamEnabled);
+
+    // ✅ stream이 바뀔 때 video에 연결
+    useEffect(() => {
+        if (videoRef.current && stream) {
+            videoRef.current.srcObject = stream;
+        }
+    }, [stream]);
 
     return (
         <div
             className={`w-[230px] h-[150px] overflow-hidden ${bgClass} rounded-xl relative ${speakingStyle}`}
         >
-            {showProfileFallback ? (
+            {!showProfileFallback && (
+                <video
+                    ref={videoRef}
+                    autoPlay
+                    playsInline
+                    muted={isLocal} // 로컬 echo 방지
+                    className='w-full h-full object-cover'
+                />
+            )}
+
+            {showProfileFallback && (
                 <div className='w-full h-full flex items-center justify-center'>
                     <div className='w-14 h-14 rounded-full overflow-hidden border-2 border-blue-500 flex items-center justify-center bg-slate-600'>
                         {profileImg ? (
@@ -38,9 +64,7 @@ export function CameraBox({ name = '이름없음', isLocal, isSpeaking, profileI
                         )}
                     </div>
                 </div>
-            ) : null}
-
-            {/* null 자리에 여기에 video 넣으면 됩니다! */}
+            )}
 
             <p className='text-white absolute left-2 bottom-1.5 font-medium text-sm flex items-center gap-1'>
                 <span>{isLocal ? 'You' : name}</span>

--- a/src/app/(main-task)/coaching-resume/_components/CameraBox.tsx
+++ b/src/app/(main-task)/coaching-resume/_components/CameraBox.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useMemo, useRef, useEffect } from 'react';
+import { useMemo, useEffect, useRef } from 'react';
 import { useCanvasStore } from '../_stores';
 
 interface ICameraBox {
@@ -9,7 +9,7 @@ interface ICameraBox {
     isLocal: boolean;
     isSpeaking: boolean;
     profileImg?: string;
-    stream?: MediaStream | null; // ✅ 추가
+    stream?: MediaStream | null;
 }
 
 export function CameraBox({
@@ -19,19 +19,19 @@ export function CameraBox({
     profileImg,
     stream,
 }: ICameraBox) {
-    const isCamEnabled = useCanvasStore((s) => s.isCamEnabled);
-    const isMicEnabled = useCanvasStore((s) => s.isMicEnabled);
     const videoRef = useRef<HTMLVideoElement>(null);
 
+    const isCamEnabled = useCanvasStore((s) => s.isCamEnabled);
+    const isMicEnabled = useCanvasStore((s) => s.isMicEnabled);
     const speakingStyle = isSpeaking ? 'ring-2 ring-blue-500' : '';
-    const bgClass = 'bg-[#0b1b2b]';
+    const bgClass = 'bg-[#0b1b2b]'; // 어두운 파란색 배경
 
     const initial = useMemo(() => {
         const base = isLocal ? 'You' : name || '';
         return base.trim().charAt(0).toUpperCase() || 'U';
     }, [isLocal, name]);
 
-    const showProfileFallback = !stream || (isLocal && !isCamEnabled);
+    const showProfileFallback = isLocal && !isCamEnabled;
 
     // ✅ stream이 바뀔 때 video에 연결
     useEffect(() => {
@@ -44,17 +44,7 @@ export function CameraBox({
         <div
             className={`w-[230px] h-[150px] overflow-hidden ${bgClass} rounded-xl relative ${speakingStyle}`}
         >
-            {!showProfileFallback && (
-                <video
-                    ref={videoRef}
-                    autoPlay
-                    playsInline
-                    muted={isLocal} // 로컬 echo 방지
-                    className='w-full h-full object-cover'
-                />
-            )}
-
-            {showProfileFallback && (
+            {showProfileFallback ? (
                 <div className='w-full h-full flex items-center justify-center'>
                     <div className='w-14 h-14 rounded-full overflow-hidden border-2 border-blue-500 flex items-center justify-center bg-slate-600'>
                         {profileImg ? (
@@ -64,7 +54,17 @@ export function CameraBox({
                         )}
                     </div>
                 </div>
+            ) : (
+                <video
+                    ref={videoRef}
+                    autoPlay
+                    playsInline
+                    muted={isLocal}
+                    className='w-full h-full object-cover'
+                />
             )}
+
+            {/* null 자리에 여기에 video 넣으면 됩니다! */}
 
             <p className='text-white absolute left-2 bottom-1.5 font-medium text-sm flex items-center gap-1'>
                 <span>{isLocal ? 'You' : name}</span>

--- a/src/app/(main-task)/coaching-resume/_components/ParticipantCamera.tsx
+++ b/src/app/(main-task)/coaching-resume/_components/ParticipantCamera.tsx
@@ -5,22 +5,16 @@ import { CameraBox } from './CameraBox';
 import { useWebRTC } from '../_hooks';
 
 export function ParticipantCamera() {
-    const { localStream, remoteStream, startCall } = useWebRTC('resume-room', {
-        onRemoteStream: (stream) => console.log('remote', stream),
-    });
-
-    console.log(remoteStream);
+    const { localStream, remoteStream, joinRoom } = useWebRTC('resume-room');
 
     useEffect(() => {
-        startCall();
-    }, [startCall]);
+        joinRoom('resume-room');
+    }, [joinRoom]);
 
     return (
         <div className='flex justify-center items-center gap-3 absolute top-5 left-1/2 -translate-x-1/2 z-10'>
-            {/* 상대방 */}
-            <CameraBox isLocal={false} isSpeaking={false} name='신우진' stream={remoteStream} />
-            {/* 나 */}
-            <CameraBox isLocal={true} isSpeaking={true} name='김민규' stream={localStream} />
+            <CameraBox isLocal={false} isSpeaking={false} name='상대방' stream={remoteStream} />
+            <CameraBox isLocal={true} isSpeaking={true} name='나' stream={localStream} />
         </div>
     );
 }

--- a/src/app/(main-task)/coaching-resume/_components/ParticipantCamera.tsx
+++ b/src/app/(main-task)/coaching-resume/_components/ParticipantCamera.tsx
@@ -1,10 +1,15 @@
 import { CameraBox } from './CameraBox';
+import { useWebRTC } from '../_hooks';
 
 export function ParticipantCamera() {
+    const { localStream, remoteStream } = useWebRTC('resume-room');
+
     return (
-        <div className='flex justify-center items-center gap-3 absolute top-5 left-1/2 -translate-x-1/2  z-10'>
-            <CameraBox isLocal={false} isSpeaking={false} name='신우진' />
-            <CameraBox isLocal={true} isSpeaking={true} name='김민규' />
+        <div className='flex justify-center items-center gap-3 absolute top-5 left-1/2 -translate-x-1/2 z-10'>
+            {/* 상대방 */}
+            <CameraBox isLocal={false} isSpeaking={false} name='신우진' stream={remoteStream} />
+            {/* 나 */}
+            <CameraBox isLocal={true} isSpeaking={true} name='김민규' stream={localStream} />
         </div>
     );
 }

--- a/src/app/(main-task)/coaching-resume/_components/ParticipantCamera.tsx
+++ b/src/app/(main-task)/coaching-resume/_components/ParticipantCamera.tsx
@@ -1,8 +1,19 @@
+'use client';
+
+import { useEffect } from 'react';
 import { CameraBox } from './CameraBox';
 import { useWebRTC } from '../_hooks';
 
 export function ParticipantCamera() {
-    const { localStream, remoteStream } = useWebRTC('resume-room');
+    const { localStream, remoteStream, startCall } = useWebRTC('resume-room', {
+        onRemoteStream: (stream) => console.log('remote', stream),
+    });
+
+    console.log(remoteStream);
+
+    useEffect(() => {
+        startCall();
+    }, [startCall]);
 
     return (
         <div className='flex justify-center items-center gap-3 absolute top-5 left-1/2 -translate-x-1/2 z-10'>

--- a/src/app/(main-task)/coaching-resume/_hooks/index.ts
+++ b/src/app/(main-task)/coaching-resume/_hooks/index.ts
@@ -9,3 +9,4 @@ export * from './useStickyNote';
 export * from './useLockTransform';
 export * from './usePdfDrop';
 export * from './useCollaborativeCursor';
+export * from './useWebRTC';

--- a/src/app/(main-task)/coaching-resume/_hooks/useWebRTC.ts
+++ b/src/app/(main-task)/coaching-resume/_hooks/useWebRTC.ts
@@ -132,30 +132,34 @@ export const useWebRTC = (room?: string, options?: Options): UseWebRTC => {
             }
         };
 
+        const handleReady = async () => {
+            console.log('✅ ready 이벤트 수신 → startCall 실행');
+            await startCall();
+        };
+
         socket.on('offer', handleOffer);
         socket.on('answer', handleAnswer);
         socket.on('ice-candidate', handleIce);
+        socket.on('ready', handleReady);
 
         return () => {
             socket.off('offer', handleOffer);
             socket.off('answer', handleAnswer);
             socket.off('ice-candidate', handleIce);
+            socket.off('ready', handleReady);
         };
     }, [attachLocalMedia, ensurePeer, socket]);
 
-    // --- joinRoom: initiator/receiver 역할 분리 ---
+    // --- joinRoom ---
     const joinRoom = useCallback(
         (roomId: string) => {
             roomRef.current = roomId;
             if (!socket) return;
 
-            socket.emit('joinRtc', roomId, async (count: number) => {
+            socket.emit('joinRtc', roomId, (count: number) => {
                 console.log(`🟢 joinRtc: ${roomId}, 현재 인원 ${count}`);
                 if (count === 1) {
-                    // 첫 참가자 → offer 생성
-                    startCall();
-                } else {
-                    console.log('🟡 다른 참가자를 기다립니다 (answer only)');
+                    console.log('🟡 방에 혼자 있음 → 다른 참가자 기다림');
                 }
             });
         },


### PR DESCRIPTION
📌 WebRTC 1:1 영상통화 기능 구현 정리
🎯 기능 목표

NestJS (백엔드) + Next.js (프론트엔드) 환경에서 1:1 영상/음성 통화 기능을 WebRTC로 구현한다.

기존에 사용 중인 CollabGateway (socket.io 기반 Yjs 동기화 서버)에 WebRTC signaling 로직을 통합한다.

시그널링 서버는 단순히 offer / answer / ICE candidate 를 교환하는 역할만 수행한다.

브라우저 간 직접 통신(P2P)으로 미디어 스트림을 주고받는다.

⚙️ 아키텍처 개요

시그널링 서버 (NestJS)

joinRtc, offer, answer, ice-candidate 이벤트 처리

방(Room)에 참가자 수를 관리해서 initiator(첫 참가자)와 responder(두 번째 참가자)를 구분

두 번째 참가자가 들어오면 첫 번째 참가자에게만 ready 이벤트를 보내 initiator가 offer를 생성하도록 유도

클라이언트 (Next.js / React Hook)

useWebRTC 훅으로 캡슐화

로컬 카메라/마이크 스트림을 확보 (navigator.mediaDevices.getUserMedia)

initiator: ready 이벤트 수신 → startCall() 실행 → offer 생성 및 송신

responder: offer 수신 → answer 생성 및 송신

양쪽 모두: ice-candidate 교환 → P2P 연결 성립 → remoteStream 업데이트

🐞 문제 / 에러 케이스 & 해결 과정
1. localStream은 나오지만 remoteStream이 계속 null

원인

두 참가자 모두 startCall()을 실행하여 offer를 중복 생성.

WebRTC에서는 initiator(offer 생성자)는 한 명만 있어야 함.

responder가 answer만 생성해야 하는데, 양쪽 다 offer를 날리면서 정상적인 SDP 교환이 깨짐.

해결 방법

서버에서 ready 이벤트를 첫 번째 참가자에게만 보내도록 수정.

initiator만 startCall()을 실행하도록 함.

if (size === 2) {
  const [firstClientId] = Array.from(this.server.sockets.adapter.rooms.get(room)!);
  this.server.to(firstClientId).emit('ready'); // initiator only
}

2. 서버 에러: TypeError: callback is not a function

원인

NestJS의 @SubscribeMessage는 기본적으로 (client, data)만 넘겨주는데,
ack callback을 쓰려면 세 번째 인자를 (client, data, callback) 형태로 명시해야 함.

해결 방법

handleJoinRtc 시그니처를 (client, room, callback)으로 정의하고, callback(size) 호출하도록 수정.

클라에서 socket.emit('joinRtc', roomId, (count) => { ... }) 형태로 ack 콜백을 받을 수 있게 됨.

3. ICE candidate가 한쪽에서만 전송됨

원인

initiator/responder 모두에서 pc.onicecandidate 이벤트가 등록돼야 하는데, 한쪽에서만 로그가 찍힘.

브라우저가 STUN 서버에 접근 못 하거나, emit 로직이 호출되지 않은 것.

해결 방법

pc.onicecandidate에 디버깅 로그 추가 → emit이 양쪽 다 되는지 확인.

STUN 서버는 구글 퍼블릭 (stun:stun.l.google.com:19302)으로 설정.

최종적으로 양쪽 모두 ICE candidate 교환 로그 확인 완료.

4. offer/answer 교환은 되는데 연결이 성립하지 않음

원인

SDP 교환 타이밍 문제 / 중복 offer 문제.

해결 방법

responder는 무조건 offer 수신 → answer 생성.

initiator는 ready 이벤트 시점에만 offer 생성.

중복 offer 제거 후 정상 연결.

5. join 이벤트와 충돌

원인

기존 join 이벤트는 Yjs 협업용, RTC 전용은 joinRtc.

같은 이름을 쓰면 충돌했음.

해결 방법

RTC 전용 이벤트는 joinRtc로 별도 분리.

서버/클라 양쪽에서 명확히 구분.

6. 브라우저 권한 팝업이 안 뜨는 문제

원인

getUserMedia가 호출되지 않거나 await 하지 않음.

훅 호출만으로 자동 실행하려 했을 때 브라우저 정책에 걸림.

해결 방법

startCall() 시점에 명시적으로 attachLocalMedia()를 호출하도록 변경.

사용자가 join → startCall 흐름에서 권한 팝업이 정상적으로 뜸.

✅ 최종 동작 흐름

첫 번째 참가자가 joinRoom('resume-room') 호출

서버: 방 인원 1 → 대기

클라: localStream 확보 후 대기

두 번째 참가자가 joinRoom('resume-room') 호출

서버: 방 인원 2 → initiator(첫 번째 참가자)에게만 ready emit

initiator → ready 수신 → startCall() 실행

localStream attach + offer 생성 + emit

responder → offer 수신 → localStream attach + answer 생성 + emit

양쪽 브라우저 → ICE candidate 교환

pc.ontrack 이벤트 실행 → remoteStream 업데이트

<video> 태그에서 양쪽 영상/음성 출력

🎉 결과

localStream / remoteStream 모두 정상적으로 세팅됨.

두 브라우저 탭(일반 ↔ 시크릿) 간 1:1 영상/음성 통화 성공.

시그널링 서버와 협업 기능(Yjs) 충돌 없이 공존 가능.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 코칭 이력서 화면에 실시간 화상 연결(WebRTC) 도입: 로컬/원격 영상 표시, 자동 재생, 좌우 반전, 마이크/카메라 토글, 통화 시작/종료 지원.
  - CameraBox가 스트리밍 비디오 렌더링을 지원하여 아바타/프로필과 실시간 영상 간 전환 가능.
- 버그 수정
  - 협업 커서 동작 안정화(SSR/프라이버시 모드 대응, 초기 연결 시 즉시 참여)로 연결 및 동기화 신뢰성 개선.
- 작업
  - 개발 서버가 모든 네트워크 인터페이스에서 접근 가능하도록 dev 스크립트 조정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->