### PR TITLE
pdf s3변환 후 업로드

### DIFF
--- a/src/app/(main-task)/coaching-resume/_apis/canvas-api.ts
+++ b/src/app/(main-task)/coaching-resume/_apis/canvas-api.ts
@@ -1,0 +1,20 @@
+import { api } from '@/apis/api';
+
+export interface CanvasImageUploadRequest {
+    dataUrl: string;
+    fileName: string;
+}
+
+export interface CanvasImageUploadResponse {
+    url: string;
+}
+
+export const canvasApi = {
+    uploadCanvasImage: async (
+        payload: CanvasImageUploadRequest,
+    ): Promise<CanvasImageUploadResponse> => {
+        const res = await api.post('/coaching-resume/canvas/upload', payload);
+        return res.data as CanvasImageUploadResponse;
+    },
+};
+

--- a/src/app/(main-task)/coaching-resume/_hooks/useCanvasImageUpload.ts
+++ b/src/app/(main-task)/coaching-resume/_hooks/useCanvasImageUpload.ts
@@ -1,0 +1,20 @@
+import { useMutation } from '@tanstack/react-query';
+import {
+    canvasApi,
+    type CanvasImageUploadRequest,
+    type CanvasImageUploadResponse,
+} from '../_apis/canvas-api';
+
+export const useCanvasImageUpload = () => {
+    const mutation = useMutation<CanvasImageUploadResponse, unknown, CanvasImageUploadRequest>({
+        mutationFn: canvasApi.uploadCanvasImage,
+    });
+
+    return {
+        uploadCanvasImage: mutation.mutateAsync,
+        isUploading: mutation.isPending,
+        error: mutation.error,
+        data: mutation.data,
+    };
+};
+

--- a/src/app/(main-task)/coaching-resume/_hooks/usePdfDrop.ts
+++ b/src/app/(main-task)/coaching-resume/_hooks/usePdfDrop.ts
@@ -1,11 +1,14 @@
 'use client';
 
 import { useEffect } from 'react';
+import { isAxiosError } from 'axios';
 import * as fabric from 'fabric';
 import { useCanvasStore } from '../_stores';
+import { useCanvasImageUpload } from './useCanvasImageUpload';
 
 export function usePdfDrop(canvasRef: React.RefObject<HTMLCanvasElement>) {
     const canvas = useCanvasStore((store) => store.canvasInstance);
+    const { uploadCanvasImage } = useCanvasImageUpload();
 
     useEffect(() => {
         if (!canvas || !canvasRef.current) return;
@@ -60,16 +63,29 @@ export function usePdfDrop(canvasRef: React.RefObject<HTMLCanvasElement>) {
 
                     console.log(`✅ 페이지 ${i} 렌더링 완료`);
 
-                    // 캔버스를 이미지 데이터로 변환
+                    // 캔버스를 이미지 데이터로 변환 후 업로드
                     const dataUrl = canvasEl.toDataURL('image/png', 0.8);
-                    console.log(
-                        `🖼️ 페이지 ${i} 이미지 데이터 생성:`,
-                        dataUrl.substring(0, 50) + '...',
-                    );
-
-                    // Fabric v6: FabricImage 사용 + await 버전
+                    const fileName = `canvas-page-${i}.png`;
+                    let imageUrl = dataUrl; // 업로드 실패 시 fallback
                     try {
-                        const img = await fabric.FabricImage.fromURL(dataUrl);
+                        const { url } = await uploadCanvasImage({ dataUrl, fileName });
+                        if (url) imageUrl = url;
+                    } catch (uploadErr) {
+                        if (isAxiosError(uploadErr)) {
+                            console.warn(
+                                `⚠️ 페이지 ${i} 업로드 실패: status=${uploadErr.response?.status}`,
+                                uploadErr.response?.data,
+                            );
+                        } else {
+                            console.warn(`⚠️ 페이지 ${i} 업로드 실패, dataUrl로 대체:`, uploadErr);
+                        }
+                    }
+
+                    // Fabric v6: 원격 URL(or dataUrl)로 이미지 생성
+                    try {
+                        const img = await fabric.FabricImage.fromURL(imageUrl, {
+                            crossOrigin: 'anonymous',
+                        } as any);
                         console.log(`🎨 페이지 ${i} Fabric 이미지 생성 완료:`, img);
 
                         if (!img) {
@@ -104,6 +120,7 @@ export function usePdfDrop(canvasRef: React.RefObject<HTMLCanvasElement>) {
                         // 메타데이터 추가
                         (img as any).pageNumber = i;
                         (img as any).isPdfPage = true;
+                        (img as any).sourceUrl = imageUrl;
 
                         // 캔버스에 추가
                         canvas.add(img);
@@ -118,7 +135,8 @@ export function usePdfDrop(canvasRef: React.RefObject<HTMLCanvasElement>) {
                 console.log('🎉 모든 페이지 처리 완료!');
             } catch (error) {
                 console.error('❌ PDF 처리 중 오류:', error);
-                alert('PDF 처리 중 오류가 발생했습니다: ' + error.message);
+                const msg = error instanceof Error ? error.message : String(error);
+                alert('PDF 처리 중 오류가 발생했습니다: ' + msg);
             } finally {
                 el.style.opacity = '1';
                 el.style.backgroundColor = 'transparent';
@@ -164,5 +182,5 @@ export function usePdfDrop(canvasRef: React.RefObject<HTMLCanvasElement>) {
             el.removeEventListener('dragover', handleDragOver);
             el.removeEventListener('dragleave', handleDragLeave);
         };
-    }, [canvas, canvasRef]);
+    }, [canvas, canvasRef, uploadCanvasImage]);
 }


### PR DESCRIPTION
- 캔버스에 드랍되는 pdf이미지가 base64가 아닌 s3로 업로드되어 링크가 삽입됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 멘토링 랜딩/목록/상세/예약(결제)/성공·실패 페이지 및 상품/리뷰 조회 추가
  - AI 인터뷰 리포트 보기(모달/페이지), 결과 카드·섹션, 프로필 이미지 업로드 추가
  - 이력서 업로드·파싱 기반 인터뷰 시작 플로우 도입
  - 코칭-이력서 대기실, 화상/음성, 협업 캔버스, 녹음 목록/재생 UI 추가
- Improvements
  - UI 라이브러리 Ant Design → shadcn/ui 전환, 아이콘 lucide-react 채택
  - AI 인터뷰 랜딩/세팅/세션 UX 전면 개편 및 오디오·비주얼 분석 표시 강화
- Documentation
  - 아키텍처/라이브러리 가이드 업데이트 및 디자인 시스템 전환 가이드 추가
- Chores
  - pnpm-lock.yaml 무시 규칙 추가
- Refactor
  - 불필요한 디버깅 로그/구 온보딩 페이지 및 구 API 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->