### PR TITLE
[ feat ] 채용공고 url 파싱 기능 추가

### DIFF
--- a/src/app/(main-task)/ai-interview/select/_apis/job-post-api.ts
+++ b/src/app/(main-task)/ai-interview/select/_apis/job-post-api.ts
@@ -1,0 +1,34 @@
+import { api } from '@/apis/api';
+
+export type JobExtractOk = {
+    ok: true;
+    url: string;
+    source: 'html' | 'ocr' | 'mixed';
+    title?: string;
+    company?: string;
+    content: string;
+    summary?: string;
+    imagesTried?: string[];
+    meta?: Record<string, string>;
+};
+
+export type JobExtractFail = {
+    ok: false;
+    url: string;
+    error?: string;
+};
+
+export type JobExtractResult = JobExtractOk | JobExtractFail;
+
+/**
+ * 채용공고 URL 사전 검증/추출 API (백엔드: POST /api/ai/job-extract)
+ */
+export const jobPostApi = {
+    extract: async (url: string, sessionId?: string): Promise<JobExtractResult> => {
+        const path = process.env.NEXT_PUBLIC_JOB_EXTRACT_PATH || 'ai/job-extract';
+        const body: any = { url };
+        if (sessionId) body.sessionId = sessionId;
+        const res = await api.post(path, body);
+        return res.data as JobExtractResult;
+    },
+};

--- a/src/app/(main-task)/ai-interview/select/page.tsx
+++ b/src/app/(main-task)/ai-interview/select/page.tsx
@@ -7,14 +7,31 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Video, CheckCircle, Loader2 } from 'lucide-react';
+import { Video, CheckCircle, Loader2, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { useResumeUpload } from './_hooks/useResumeUpload';
+import { api } from '@/apis/api';
+import { jobPostApi } from './_apis/job-post-api';
 
 export default function AiInterviewSelectPage() {
     const [jobPostUrl, setJobPostUrl] = useState('');
     const [activeTab, setActiveTab] = useState('resume');
     const [buttonAnimation, setButtonAnimation] = useState(false);
     const [isCheckingEnvironment, setIsCheckingEnvironment] = useState(false);
+    const [isVerifyingJob, setIsVerifyingJob] = useState(false);
+    const [jobVerifyState, setJobVerifyState] = useState<'idle' | 'verifying' | 'success' | 'fail'>(
+        'idle',
+    );
+    const [jobMeta, setJobMeta] = useState<{
+        title?: string;
+        company?: string;
+        source?: string;
+        url?: string;
+        content?: string;
+        ts?: number;
+    } | null>(null);
+    const [jobVerifyNotice, setJobVerifyNotice] = useState<'none' | 'success' | 'failed'>('none');
+    const [urlError, setUrlError] = useState<string | null>(null);
     const [currentMessageIndex, setCurrentMessageIndex] = useState(0);
     const router = useRouter();
 
@@ -45,27 +62,63 @@ export default function AiInterviewSelectPage() {
             return;
         }
 
-        // 채용공고 URL이 입력된 경우에만 유효성 검사
-        if (jobPostUrl.trim()) {
-            // 사람인 사이트 URL인지 확인
-            if (!jobPostUrl.includes('saramin.co.kr')) {
-                alert('사람인 사이트의 채용공고 URL만 입력할 수 있습니다.');
-                return;
-            }
-
-            // URL 유효성 검사
-            try {
-                new URL(jobPostUrl);
-            } catch {
-                alert('올바른 URL 형식을 입력해주세요.');
-                return;
-            }
-        }
-
-        // 환경 체크 시작
-        setIsCheckingEnvironment(true);
+        // (이전 단계) 중복된 사전 추출 로직 제거됨 – 아래에서 일괄 처리합니다.
 
         try {
+            // 채용공고 URL이 입력된 경우: 형식 검증 + 백엔드 사전 추출
+            if (jobPostUrl.trim()) {
+                try {
+                    new URL(jobPostUrl);
+                } catch {
+                    setUrlError('올바른 URL 형식을 입력해주세요.');
+                    return;
+                }
+
+                setIsVerifyingJob(true);
+                setJobVerifyState('verifying');
+                try {
+                    const sid =
+                        typeof window !== 'undefined'
+                            ? localStorage.getItem('aiInterviewSessionId') || undefined
+                            : undefined;
+                    const result = await jobPostApi.extract(jobPostUrl.trim(), sid);
+                    if (result.ok) {
+                        const meta = {
+                            url: result.url,
+                            title: result.title,
+                            company: result.company,
+                            source: result.source,
+                            // 서버에서 생성한 요약을 그대로 저장 (세션 캐시와 일관)
+                            summary: result.summary,
+                            content: undefined,
+                            ts: Date.now(),
+                        };
+                        setJobMeta(meta);
+                        setJobVerifyState('success');
+                        setJobVerifyNotice('success');
+                        try {
+                            sessionStorage.setItem('jobPostMeta', JSON.stringify(meta));
+                        } catch {}
+                    } else {
+                        setJobVerifyState('fail');
+                        setJobVerifyNotice('failed');
+                    }
+                } catch (e) {
+                    console.error('채용공고 사전 추출 실패:', e);
+                    setJobVerifyState('fail');
+                    setJobVerifyNotice('failed');
+                } finally {
+                    setIsVerifyingJob(false);
+                }
+            } else {
+                setJobVerifyState('idle');
+                setJobVerifyNotice('none');
+                setUrlError(null);
+            }
+
+            // 환경 체크 시작 (검증 이후 진행)
+            setIsCheckingEnvironment(true);
+
             // 이력서가 업로드된 경우 파싱 시작
             if (uploadedFile) {
                 await startParsing(uploadedFile.id);
@@ -104,6 +157,36 @@ export default function AiInterviewSelectPage() {
         '면접 준비가 한창이에요...',
         'AI 면접관이 준비 중입니다...',
     ];
+
+    // 초기 세션 생성(선택 진입 시 즉시 발급) + 기존 세션 산출물 정리
+    useEffect(() => {
+        try {
+            // 이전 세션 산출물(지표/리포트 캐시)은 혼선 방지를 위해 정리
+            const keysToClear = [
+                'interviewAudioOverallServer',
+                'interviewAudioPerQuestionServer',
+                'interviewAudioOverall',
+                'interviewAudioPerQuestion',
+                'interviewVisualOverall',
+                'interviewVisualPerQuestion',
+                'interviewAnalysis',
+                'interviewQA',
+            ];
+            keysToClear.forEach((k) => localStorage.removeItem(k));
+        } catch {}
+
+        try {
+            const sid = `sess_${Math.random().toString(36).slice(2, 10)}_${Date.now()}`;
+            localStorage.setItem('aiInterviewSessionId', sid);
+
+            // 인터뷰 세션 보장: finalize를 호출하면 interview_sessions에 INSERT IGNORE 됨
+            api.post(`/metrics/${sid}/finalize`, {}, { timeout: 10000 }).catch((e) =>
+                console.warn('세션 보장(finalize) 실패 또는 무시 가능:', e),
+            );
+        } catch (e) {
+            console.warn('세션 ID 초기화 실패:', e);
+        }
+    }, []);
 
     // 랜덤 메시지 변경
     useEffect(() => {
@@ -148,6 +231,19 @@ export default function AiInterviewSelectPage() {
                                 <p className='text-lg min-h-[1.5rem] transition-all duration-500 ease-in-out'>
                                     {waitingMessages[currentMessageIndex]}
                                 </p>
+
+                                {/* 채용공고 검증 결과 안내 */}
+                                {jobVerifyNotice === 'failed' && (
+                                    <Alert className='border-yellow-300 bg-yellow-50 text-left'>
+                                        <AlertTitle className='text-yellow-800'>
+                                            채용공고 확인 실패
+                                        </AlertTitle>
+                                        <AlertDescription className='text-yellow-700'>
+                                            채용공고 확인에 실패했습니다. 이력서 기반으로 면접이
+                                            진행됩니다.
+                                        </AlertDescription>
+                                    </Alert>
+                                )}
 
                                 {/* 점 3개 애니메이션 */}
                                 <div className='flex items-center justify-center gap-1'>
@@ -375,6 +471,7 @@ export default function AiInterviewSelectPage() {
                                             value={jobPostUrl}
                                             onChange={(e) => {
                                                 setJobPostUrl(e.target.value);
+                                                setUrlError(null);
                                                 // URL 입력 시 버튼 애니메이션 트리거
                                                 setButtonAnimation(true);
                                                 setTimeout(() => setButtonAnimation(false), 1000);
@@ -383,12 +480,69 @@ export default function AiInterviewSelectPage() {
                                         />
                                     </div>
 
+                                    {/* URL 형식 오류 */}
+                                    {urlError && (
+                                        <Alert variant='destructive'>
+                                            <AlertTitle>입력 오류</AlertTitle>
+                                            <AlertDescription>{urlError}</AlertDescription>
+                                        </Alert>
+                                    )}
+
+                                    {/* 검증 상태 표시 */}
+                                    {isVerifyingJob && (
+                                        <Alert className='border-sky-300 bg-sky-50'>
+                                            <AlertTitle className='text-sky-800'>
+                                                채용공고 확인 중
+                                            </AlertTitle>
+                                            <AlertDescription className='flex items-center gap-2 text-sky-700'>
+                                                <Loader2 className='w-4 h-4 animate-spin' /> 잠시만
+                                                기다려주세요...
+                                            </AlertDescription>
+                                        </Alert>
+                                    )}
+                                    {!isVerifyingJob && jobVerifyState === 'success' && jobMeta && (
+                                        <Alert className='border-green-300 bg-green-50'>
+                                            <AlertTitle className='text-green-800'>
+                                                채용공고 확인됨
+                                            </AlertTitle>
+                                            <AlertDescription className='text-green-700'>
+                                                {jobMeta.title || jobMeta.company ? (
+                                                    <span>
+                                                        {jobMeta.title
+                                                            ? `제목: ${jobMeta.title}`
+                                                            : ''}
+                                                        {jobMeta.title && jobMeta.company
+                                                            ? ' / '
+                                                            : ''}
+                                                        {jobMeta.company
+                                                            ? `회사: ${jobMeta.company}`
+                                                            : ''}
+                                                    </span>
+                                                ) : (
+                                                    <span>채용공고를 성공적으로 확인했습니다.</span>
+                                                )}
+                                            </AlertDescription>
+                                        </Alert>
+                                    )}
+                                    {!isVerifyingJob && jobVerifyState === 'fail' && (
+                                        <Alert className='border-yellow-300 bg-yellow-50'>
+                                            <AlertTitle className='text-yellow-800'>
+                                                채용공고 확인 실패
+                                            </AlertTitle>
+                                            <AlertDescription className='text-yellow-700'>
+                                                채용공고 확인에 실패했습니다. 이력서 기반으로 면접이
+                                                진행됩니다.
+                                            </AlertDescription>
+                                        </Alert>
+                                    )}
+
                                     {jobPostUrl &&
                                         (() => {
                                             try {
                                                 new URL(jobPostUrl);
                                                 const isSaraminUrl =
-                                                    jobPostUrl.includes('saramin.co.kr');
+                                                    // jobPostUrl.includes('saramin.co.kr');
+                                                    true;
                                                 return (
                                                     <div
                                                         className={`p-4 border rounded-lg ${

--- a/src/app/(main-task)/ai-interview/sessions/_apis/interview-api.ts
+++ b/src/app/(main-task)/ai-interview/sessions/_apis/interview-api.ts
@@ -51,7 +51,11 @@ export class InterviewAPI {
         }
 
         const jobPostUrl = sessionStorage.getItem('jobPostUrl') || undefined;
-        const payload: any = {};
+        const sessionId =
+            typeof window !== 'undefined'
+                ? localStorage.getItem('aiInterviewSessionId') || undefined
+                : undefined;
+        const payload: any = sessionId ? { sessionId } : {};
         if (selectedResumeId) payload.resumeFileId = selectedResumeId;
         else payload.resumeSummary = resumeSummary;
         if (jobPostUrl) payload.jobPostUrl = jobPostUrl;
@@ -65,9 +69,13 @@ export class InterviewAPI {
      * 후속 질문을 생성합니다
      */
     static async fetchFollowup(original: QuestionDto, answer: string): Promise<QuestionDto> {
+        const sessionId =
+            typeof window !== 'undefined'
+                ? localStorage.getItem('aiInterviewSessionId') || undefined
+                : undefined;
         const res = await api.post(
             `ai/followups`,
-            { originalQuestion: original, answer },
+            { originalQuestion: original, answer, ...(sessionId ? { sessionId } : {}) },
             { timeout: 60000 },
         );
         const data = res.data as {

--- a/src/app/(main-task)/ai-interview/setting/page.tsx
+++ b/src/app/(main-task)/ai-interview/setting/page.tsx
@@ -157,7 +157,7 @@ export default function AiInterviewSettingCalibrationCombined() {
         };
     }, [phase]);
 
-    // 초기 세션 생성(항상 신규) + 장치 존재 체크
+    // 장치 존재 체크 + 기존 세션 ID 로드
     useEffect(() => {
         (async () => {
             try {
@@ -168,37 +168,13 @@ export default function AiInterviewSettingCalibrationCombined() {
                 setWebcamOk(false);
                 setMicOk(false);
             }
-            // 세션 ID: 설정 페이지 진입 시마다 항상 신규 발급
+            // Select 페이지에서 생성된 세션 ID를 로드
             try {
-                const prevSid = localStorage.getItem('aiInterviewSessionId');
-                // 이전 세션 산출물(지표/리포트 캐시)은 혼선 방지를 위해 정리
-                try {
-                    const keysToClear = [
-                        'interviewAudioOverallServer',
-                        'interviewAudioPerQuestionServer',
-                        'interviewAudioOverall',
-                        'interviewAudioPerQuestion',
-                        'interviewVisualOverall',
-                        'interviewVisualPerQuestion',
-                        'interviewAnalysis',
-                        'interviewQA',
-                    ];
-                    keysToClear.forEach((k) => localStorage.removeItem(k));
-                } catch {}
-
-                const sid = `sess_${Math.random().toString(36).slice(2, 10)}_${Date.now()}`;
-                localStorage.setItem('aiInterviewSessionId', sid);
-                setSessionId(sid);
-
-                // 인터뷰 세션 보장: finalize를 호출하면 interview_sessions에 INSERT IGNORE 됨
-                try {
-                    await api.post(`/metrics/${sid}/finalize`, {}, { timeout: 10000 });
-                } catch (e) {
-                    // 비어있는 세션 finalize는 실패해도 무방하므로 로그만
-                    console.warn('세션 보장(finalize) 실패 또는 무시 가능:', e);
-                }
+                const sid = localStorage.getItem('aiInterviewSessionId');
+                if (sid) setSessionId(sid);
+                else console.warn('세션 ID가 없습니다. 선택 페이지에서 세션을 생성하세요.');
             } catch (e) {
-                console.warn('세션 ID 초기화 실패:', e);
+                console.warn('세션 ID 로드 실패:', e);
             }
         })();
     }, []);
@@ -283,8 +259,7 @@ export default function AiInterviewSettingCalibrationCombined() {
                         }),
                     );
 
-                    // 세션 ID 저장 (면접에서 사용)
-                    localStorage.setItem('calibrationSessionId', sessionId);
+                    // 별도 calibrationSessionId 저장 불필요: aiInterviewSessionId를 그대로 사용
                 }
             }
 


### PR DESCRIPTION
- 채용공고 url에서 내용을 파싱하고, OpenAI LLM을 이용해 요약하여 질문 생성 로직에 반영합니다.
- 현재 사람인 이외의 사이트도 우회에 성공할 경우 파싱이 가능하지만, 표기에 아직 반영되지 않았습니다.
- 파싱에 실패할 경우에는 "이력서 기반으로 면접을 진행합니다"라는 메세지를 띄우고, 그대로 진행이 가능합니다.